### PR TITLE
Switch matplotlib dependency to matplotlib-base

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 About lalinference
 ==================
 
-Home: https://wiki.ligo.org/Computing/DASWG/LALSuite
+Home: https://wiki.ligo.org/Computing/LALSuite
 
-Package license: GPLv3
+Package license: GPL-3.0-or-later
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
   error_overlinking: true
   ignore_run_exports:
     - hdf5  # [osx]
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -124,7 +124,7 @@ outputs:
         - {{ pin_subpackage('lalinference', exact=True) }}
         - libcblas  # [linux]
         - lscsoft-glue >=1.54.1
-        - matplotlib >=1.2.0
+        - matplotlib-base >=1.2.0
         - {{ pin_compatible('numpy') }}
         - python
         - python-lal >={{ lal_version }}


### PR DESCRIPTION
`python-lalinference` doesn't require the interactive portions of `matplotlib`, so we can just depend on `matplotlib-base,` which is a much smaller footprint.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
