### PR TITLE
Add run_constrained and rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -126,6 +126,8 @@ outputs:
         - python-lalpulsar >={{ lalpulsar_version }}
         - python-ligo-lw
         - scipy >=0.9.0
+        # lalsuite swig bindings segfault with numpy 1.20.0
+        - numpy <1.20.0a0
     test:
       requires:
         - pytest >=4.0.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,9 @@ outputs:
         - liblalinspiral >={{ lalinspiral_version }}
         - liblalpulsar >={{ lalpulsar_version }}
         - llvm-openmp  # [osx]
+      run_constrained:
+        - lalinference >=2.0.6
+        - python-lalinference >=2.0.6
     test:
       requires:
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -189,28 +189,34 @@ outputs:
         - {{ pin_subpackage('python-lalinference', exact=True) }}
         # run requirements needed for help2man
         - astropy >=1.1.1
-        - healpy >=1.9.1
         - h5py
-        - ligo-segments
+        - ligo-gracedb
         - lscsoft-glue >=1.54.1
         - matplotlib-base >=1.2.0
         - python-lal >={{ lal_version }}
-        - python-lalmetaio >={{ lalmetaio_version }}
         - python-lalsimulation >={{ lalsimulation_version }}
-        - python-lalburst >={{ lalburst_version }}
-        - python-lalinspiral >={{ lalinspiral_version }}
-        - python-lalpulsar >={{ lalpulsar_version }}
         - python-ligo-lw
         - scipy >=0.9.0
+        - six
       run:
+        - astropy >=1.1.1
         - gsl  # [mpi != 'nompi']
+        - h5py
         - liblal >={{ lal_version }}
         - {{ pin_subpackage('liblalinference', exact=True) }}
         - liblalinspiral >={{ lalinspiral_version }}  # [mpi != 'nompi']
+        - ligo-gracedb
         - llvm-openmp  # [osx and mpi != 'nompi']
+        - lscsoft-glue >=1.54.1
+        - matplotlib-base >=1.2.0
         - {{ mpi }}  # [mpi != 'nompi']
         - python
+        - python-lal >={{ lal_version }}
         - {{ pin_subpackage('python-lalinference', exact=True) }}
+        - python-lalsimulation >={{ lalsimulation_version }}
+        - python-ligo-lw
+        - scipy >=0.9.0
+        - six
     test:
       requires:
         - cpnest


### PR DESCRIPTION
This PR is mainly to build out lalinference 2.0.6 now that lal [has been rebuilt](https://github.com/conda-forge/lal-feedstock/pull/49) to fix a numpy issue, but also adds a run_constrained relevant to the repackaging introduced in #32.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
