### PR TITLE
Replace legacy ligo-segments dependency with igwn-segments

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "lalinference" %}
 {% set version = "4.1.9" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # dependencies
 {% set lal_version = "7.7.0" %}
@@ -167,7 +167,7 @@ outputs:
         - h5py
         - igwn-ligolw >=2.1.0
         - {{ pin_subpackage('liblalinference', exact=True) }}
-        - ligo-segments
+        - igwn-segments
         - lscsoft-glue >=1.54.1
         - matplotlib-base >=1.2.0
         - python


### PR DESCRIPTION
This PR updates an old dependency.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
